### PR TITLE
Update json response's country code key

### DIFF
--- a/android/src/main/java/com/reactnativedevicecountry/DeviceCountryModule.java
+++ b/android/src/main/java/com/reactnativedevicecountry/DeviceCountryModule.java
@@ -62,7 +62,7 @@ public class DeviceCountryModule extends ReactContextBaseJavaModule {
     }
     try {
       JSONObject json = new JSONObject();
-      json.put("countryCode", countryCode);
+      json.put("code", countryCode);
       json.put("type", type);
       return json;
     } catch (Exception e) {


### PR DESCRIPTION
The `ResolveType` interface expects a `code` key but the android implementation is returning `countryCode`