### PR TITLE
Fix error during assembleRelease with react-native@0.69.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('DeviceCountry_compileSdkVersion', 29)
+    compileSdkVersion safeExtGet('DeviceCountry_compileSdkVersion', 31)
     buildToolsVersion safeExtGet('DeviceCountry_buildToolsVersion', '29.0.2')
     defaultConfig {
         minSdkVersion safeExtGet('DeviceCountry_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('DeviceCountry_targetSdkVersion', 29)
+        targetSdkVersion safeExtGet('DeviceCountry_targetSdkVersion', 31)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
This resolves an error I'm getting when running `gradle assembleRelease` 

```
Execution failed for task ':react-native-device-country:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:~/.gradle/caches/transforms-3/e6a7b0cb90c4290418ec2361cd5de7d3/transformed/core-1.7.0/res/values/values.xml:105:5-114:25: AAPT: error: resource android:attr/lStar not found.
```

I'm currently setting these props in my build.gradle as a workaround
```
buildscript {
    ext {
        ...
        DeviceCountry_compileSdkVersion = 31
        DeviceCountry_targetSdkVersion = 31
```